### PR TITLE
Mailer4D.Mapi.Impl.pas

### DIFF
--- a/src/Mailer4D.Mapi.Impl.pas
+++ b/src/Mailer4D.Mapi.Impl.pas
@@ -113,7 +113,7 @@ begin
         for I := 0 to Pred(GetAttachments.Count) do
         begin
           a^.lpszPathName := StrNew(PAnsiChar(AnsiString(GetAttachments.Strings[I])));
-          a^.lpszFileName := StrNew(PAnsiChar(AnsiString(GetAttachments.Strings[I])));
+          a^.lpszFileName := StrNew(PAnsiChar(AnsiString(ExtractFileName(GetAttachments.Strings[i]))));
           a^.ulReserved := 0;
           a^.flFlags := 0;
           a^.nPosition := Cardinal($FFFFFFFF);


### PR DESCRIPTION
Quando anexo um arquivo estava aparecendo o nome com o caminho, fiz a alteração para mostrar somente o nome do arquivo.
a^.lpszFileName := StrNew(PAnsiChar(AnsiString(GetAttachments.Strings[i])));
para:
a^.lpszFileName := StrNew(PAnsiChar(AnsiString(ExtractFileName(GetAttachments.Strings[i]))));