### PR TITLE
Replace line breaks by <br> when using HTML format at base class

### DIFF
--- a/src/Mailer4D.Base.Impl.pas
+++ b/src/Mailer4D.Base.Impl.pas
@@ -48,7 +48,7 @@ type
     function IsWithConfirmation: Boolean;
     function GetAttachments: TStringList;
     function GetSubject: string;
-    function GetMessage: TStringList;
+    function GetMessage: string;
     function IsWithHTML: Boolean;
 
     procedure DoSend; virtual; abstract;
@@ -199,9 +199,12 @@ begin
   Result := fHTML;
 end;
 
-function TBaseMailer.GetMessage: TStringList;
+function TBaseMailer.GetMessage: string;
 begin
-  Result := fMessage;
+  if fHTML then
+    Result := StringReplace(fMessage.Text, sLineBreak, '<br>', [rfReplaceAll])
+  else
+    Result := fMessage.Text;
 end;
 
 function TBaseMailer.GetPassword: string;

--- a/src/Mailer4D.Indy.Impl.pas
+++ b/src/Mailer4D.Indy.Impl.pas
@@ -67,7 +67,7 @@ var
   body: TIdText;
 begin
   body := TIdText.Create(msg.MessageParts);
-  body.Body.Text := GetMessage.Text;
+  body.Body.Text := GetMessage;
   if IsWithHTML then
     body.ContentType := 'text/html; charset="UTF-8"'
   else

--- a/src/Mailer4D.Mapi.Impl.pas
+++ b/src/Mailer4D.Mapi.Impl.pas
@@ -57,7 +57,7 @@ begin
     try
       msg.ulReserved := 0;
       msg.lpszSubject := PAnsiChar(AnsiString(GetSubject));
-      msg.lpszNoteText := PAnsiChar(AnsiString(GetMessage.Text));
+      msg.lpszNoteText := PAnsiChar(AnsiString(GetMessage));
       msg.lpszMessageType := nil;
       msg.lpszDateReceived := nil;
       msg.lpszConversationID := nil;

--- a/src/Mailer4D.Outlook.Impl.pas
+++ b/src/Mailer4D.Outlook.Impl.pas
@@ -55,12 +55,12 @@ begin
   if IsWithHTML then
   begin
     email.BodyFormat := olFormatHTML;
-    email.HTMLBody := StringReplace(GetMessage.Text, sLineBreak, '<br>', [rfReplaceAll]);
+    email.HTMLBody := GetMessage;
   end
   else
   begin
     email.BodyFormat := olFormatPlain;
-    email.Body := GetMessage.Text;
+    email.Body := GetMessage;
   end;
 end;
 

--- a/src/Mailer4D.Synapse.Impl.pas
+++ b/src/Mailer4D.Synapse.Impl.pas
@@ -31,6 +31,8 @@ type
 
 implementation
 
+uses
+  System.Classes;
 
 { TSynapseMailer }
 
@@ -43,11 +45,20 @@ begin
 end;
 
 procedure TSynapseMailer.AddBody(const mime: TMimemess; const mimepart: TMimepart);
+var
+  msg: TStrings;
 begin
-  if IsWithHTML then
-    mime.AddPartHTML(GetMessage, mimepart)
-  else
-    mime.AddPartText(GetMessage, mimepart);
+  msg := TStringList.Create;
+  try
+    msg.Text := GetMessage;
+
+    if IsWithHTML then
+      mime.AddPartHTML(msg, mimepart)
+    else
+      mime.AddPartText(msg, mimepart);
+  finally
+    msg.Free;
+  end;
 end;
 
 procedure TSynapseMailer.AddCcRecipients(const mime: TMimemess);


### PR DESCRIPTION
Change GetMessage function at base class to return a string and replace line breaks by <br> when using HTML format, so it doesn't need to replace it at every mailer class